### PR TITLE
Fix 'flashing tooltips' when mouse hits slots in the top right corner of the screen

### DIFF
--- a/core/src/com/pixelscientists/gdx/inventory/SlotActor.java
+++ b/core/src/com/pixelscientists/gdx/inventory/SlotActor.java
@@ -45,6 +45,7 @@ public class SlotActor extends ImageButton implements SlotListener {
 		slot.addListener(this);
 
 		SlotTooltip tooltip = new SlotTooltip(slot, skin);
+		tooltip.setTouchable(Touchable.disabled); // allows for mouse to hit tooltips in the top-right corner of the screen without flashing
 		InventoryScreen.stage.addActor(tooltip);
 		addListener(new TooltipListener(tooltip, true));
 	}


### PR DESCRIPTION
Allows for mouse to hit tooltips in the top-right corner of the screen.
The slot InputListener won't fire an 'exit' event when the mouse hits
the tooltip and is still inside the slot. This is achieved by disabling
touch events (no need to touch a tooltip anyway).
